### PR TITLE
Fix dynamically assigned properties bug

### DIFF
--- a/RMS Seamless Plugin for Magento 2.4.x/RazerPay/Payment/Domain/PaymentDomain.php
+++ b/RMS Seamless Plugin for Magento 2.4.x/RazerPay/Payment/Domain/PaymentDomain.php
@@ -40,7 +40,7 @@ class PaymentDomain
         $this->magentoSalesInvoiceSender = $magentoSalesInvoiceSender;
         $this->magentoSalesInvoiceService = $magentoSalesInvoiceService;
         $this->paymentReturnIpnRequestFactory = $paymentReturnIpnRequestFactory;
-        $this->paymentCaputreRequestFactory = $paymentCaptureRequestFactory;
+        $this->paymentCaptureRequestFactory = $paymentCaptureRequestFactory;
         $this->paymentDataDomain = $paymentDataDomain;
         $this->paymentGatewayConfig = $paymentGatewayConfig;
     }
@@ -211,7 +211,7 @@ class PaymentDomain
         /**
          * @var \RazerPay\Payment\Domain\Api\CaptureRequest $request
          */
-        $request = $this->paymentCaputreRequestFactory->create([
+        $request = $this->paymentCaptureRequestFactory->create([
             'bodyParams' => [
                 'tran_id' => $salesOrderPaymentAuthorizationTransaction->getTxnId(),
                 'ref_id' => $salesOrderPayment->getOrder()->getIncrementId(),


### PR DESCRIPTION
- Fix dynamically assigned properties bug.  
- "Deprecated functionality: Creation of dynamic property is deprecated" in Magento 2.4.7-p3 is related to PHP 8.2 compatibility.
- Why This Happens? Magento 2.4.7-p3 supports PHP 8.2, which deprecates dynamic properties. This means you can no longer create object properties dynamically (i.e., without pre-defining them in the class).