### PR TITLE
Fix outdated RazerMS/MOLPay branding in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,35 +1,35 @@
 [IMPORTANT - THIS PLUGIN IS CURRENTLY UNDER MAINTENENCE, PLEASE DO NOT USE UNTIL FURTHER NOTICE]  
-[Shopping Cart Plugins] – RazerMS Magento
+[Shopping Cart Plugins] – Fiuu Magento
 =====================
 
 <img src="https://user-images.githubusercontent.com/38641542/74420751-e99a2900-4e86-11ea-99e6-904e4eba1574.jpg">
 
-The Razer Merchant Services Magento Plugin makes it easy to add MOLPay payment gateway to your Magento shopping cart.
+The Fiuu Magento Plugin makes it easy to add Fiuu payment gateway to your Magento shopping cart.
 
-###### MOLPay Plugin for Magento Community Edition ######
+###### Fiuu Plugin for Magento Community Edition ######
 
 
 Important Notice 
 ----------------
 
-* As 2nd July 2020, for those who are already used this plugin, kindly change https://sandbox.molpay.com/ to https://sandbox.merchant.razer.com/ to avoid any unnecessary error during your testing payment in RMS Sandbox Environment.
+* As 2nd July 2020, for those who are already used this plugin, kindly change https://sandbox.molpay.com/ to https://sandbox.fiuu.com/ to avoid any unnecessary error during your testing payment in Fiuu Sandbox Environment.
 * Latest plugin has published with respective changes as in this link 
-https://github.com/RazerMS/Shopping-Cart-Plugins-RazerMS_Magento/blob/master/RMS%20Seamless%20Plugin%20for%20Magento%202.4.x/magento2-module-razerpay-payment-1.0.0-20230807.zip
+https://github.com/FiuuPayment/Shopping-Cart-Plugins-Fiuu_Magento/blob/master/RMS%20Seamless%20Plugin%20for%20Magento%202.4.x/magento2-module-razerpay-payment-1.0.0-20230807.zip
 
 Prerequisites
 -------------
 
 * PHP 5.2 or later. 
 * For Magento 2.2.x and above , recommend to use PHP 7.0 and above
-* MOLPay Production or Development [account](https://merchant.razer.com/v3/enrol-with-us/).
+* Fiuu Production or Development [account](https://fiuu.com/).
 
 Documentation
 -------------
 
-* [Getting Started](https://github.com/RazerMS/Magento_Plugin/wiki#getting-started) - Everything you need to begin using this plugins.
-* [Contributing to the Plugin](https://github.com/RazerMS/Magento_Plugin/wiki/Contributing-to-the-Plugin)
+* [Getting Started](https://github.com/FiuuPayment/Shopping-Cart-Plugins-Fiuu_Magento/wiki#getting-started) - Everything you need to begin using this plugins.
+* [Contributing to the Plugin](https://github.com/FiuuPayment/Shopping-Cart-Plugins-Fiuu_Magento/wiki/Contributing-to-the-Plugin)
 
-General documentation regarding the MOLPay API and related payment flows can be found on the MOLPay Merchant Admin Site.
+General documentation regarding the Fiuu API and related payment flows can be found on the Fiuu Merchant Admin Site.
 
 **Disclaimer : Any amendment by your end is at your own risk.**
 
@@ -39,43 +39,43 @@ Plugin Releases
 *Version Magento 1.x.x*
 
 **Normal Integration**
-* [MOLPay Plugin for Magento Version 1.9.2.X](https://github.com/RazerMS/Magento_Plugin/tree/Version-1.9.2.x)
+* [Fiuu Plugin for Magento Version 1.9.2.X](https://github.com/FiuuPayment/Shopping-Cart-Plugins-Fiuu_Magento/tree/Version-1.9.2.x)
 
 **Seamless Integration**
-* [MOLPay Seamless Plugin for Magento Version 1.9.3.X - Default Checkout ](https://github.com/RazerMS/Magento_Plugin/tree/Version-1.9.3.x)
-* [MOLPay Seamless Plugin for Magento Version 1.9.3.X - IWD One Page Checkout ](https://github.com/RazerMS/Magento_Plugin/tree/Version-1.9.3.x)
-* [MOLPay Seamless Plugin for Magento Version 1.9.2.X - Default Checkout ](https://github.com/RazerMS/Magento_Plugin/tree/Version-1.9.2.x)
-* [MOLPay Seamless Plugin for Magento Version 1.9.2.X - Aheadworks Checkout v1.3.5 ](https://github.com/MOLPay/Magento_Plugin/tree/Version-1.9.2.x)
-* [MOLPay Seamless Plugin for Magento Version 1.9.2.X - Firecheckout ](https://github.com/RazerMS/Magento_Plugin/tree/Version-1.9.2.x)
-* [MOLPay Seamless Plugin for Magento Version 1.9.2.X - SuperTheme ](https://github.com/RazerMS/Magento_Plugin/tree/Version-1.9.2.x)
+* [Fiuu Seamless Plugin for Magento Version 1.9.3.X - Default Checkout ](https://github.com/FiuuPayment/Shopping-Cart-Plugins-Fiuu_Magento/tree/Version-1.9.3.x)
+* [Fiuu Seamless Plugin for Magento Version 1.9.3.X - IWD One Page Checkout ](https://github.com/FiuuPayment/Shopping-Cart-Plugins-Fiuu_Magento/tree/Version-1.9.3.x)
+* [Fiuu Seamless Plugin for Magento Version 1.9.2.X - Default Checkout ](https://github.com/FiuuPayment/Shopping-Cart-Plugins-Fiuu_Magento/tree/Version-1.9.2.x)
+* [Fiuu Seamless Plugin for Magento Version 1.9.2.X - Aheadworks Checkout v1.3.5 ](https://github.com/FiuuPayment/Shopping-Cart-Plugins-Fiuu_Magento/tree/Version-1.9.2.x)
+* [Fiuu Seamless Plugin for Magento Version 1.9.2.X - Firecheckout ](https://github.com/FiuuPayment/Shopping-Cart-Plugins-Fiuu_Magento/tree/Version-1.9.2.x)
+* [Fiuu Seamless Plugin for Magento Version 1.9.2.X - SuperTheme ](https://github.com/FiuuPayment/Shopping-Cart-Plugins-Fiuu_Magento/tree/Version-1.9.2.x)
 
 
 *Version Magento 2.x.x*
 
-* [MOLPay Seamless Plugin for Magento Version 2.1.X & 2.2.X (Default Checkout)](https://github.com/RazerMS/Magento_Plugin/tree/master/MOLPay%20Seamless%20Plugin%20for%20Magento%202.1.x%202.2.x/DefaultCheckout/Latest_Release)
-* [MOLPay Seamless Plugin for Magento Version 2.1.X & 2.2.X (OneStepCheckout)](https://github.com/RazerMS/Magento_Plugin/tree/master/MOLPay%20Seamless%20Plugin%20for%20Magento%202.1.x%202.2.x/OneStepCheckout)
-* [MOLPay Seamless Plugin for Magento Version 2.0.X](https://github.com/RazerMS/Magento_Plugin/tree/master/MOLPay%20Seamless%20Plugin%20for%20Magento%202.0.x)
+* [Fiuu Seamless Plugin for Magento Version 2.1.X & 2.2.X (Default Checkout)](https://github.com/FiuuPayment/Shopping-Cart-Plugins-Fiuu_Magento/tree/Version-2.2.x)
+* [Fiuu Seamless Plugin for Magento Version 2.1.X & 2.2.X (OneStepCheckout)](https://github.com/FiuuPayment/Shopping-Cart-Plugins-Fiuu_Magento/tree/Version-2.2.x)
+* [Fiuu Seamless Plugin for Magento Version 2.0.X](https://github.com/FiuuPayment/Shopping-Cart-Plugins-Fiuu_Magento/tree/Version-2.0.x)
 
 
 ## Resources
 
-- GitHub:     https://github.com/RazerMS
-- Website:    https://merchant.razer.com/
-- Twitter:    https://twitter.com/Razer_MS
-- YouTube:    https://www.youtube.com/c/RazerMerchantServices
-- Facebook:   https://www.facebook.com/RazerMerchantServices/
-- Instagram:  https://www.instagram.com/RazerMerchantServices/
+- GitHub:     https://github.com/FiuuPayment
+- Website:    https://fiuu.com/
+- X:          https://x.com/FiuuPayment
+- YouTube:    https://www.youtube.com/@FiuuPayment
+- Facebook:   https://www.facebook.com/FiuuPayment
+- Instagram:  https://www.instagram.com/fiuupayment
 
 
 Support
 -------
 
-Merchant Technical Support / Customer Care : support-sa@razer.com <br>
-Marketing Campaign : marketing-sa@razer.com <br>
-Channel/Partner Enquiry : channel-sa@razer.com <br>
-Media Contact : media-sa@razer.com <br>
-R&D and Tech-related Suggestion : technical-sa@razer.com <br>
-Abuse Reporting : abuse-sa@razer.com
+Merchant Technical Support / Customer Care : support@fiuu.com <br>
+Marketing Campaign : marketing@fiuu.com <br>
+Channel/Partner Enquiry : channel@fiuu.com <br>
+Media Contact : media@fiuu.com <br>
+R&D and Tech-related Suggestion : technical@fiuu.com <br>
+Abuse Reporting : abuse@fiuu.com
 
 Disclaimer
 ----------


### PR DESCRIPTION
## Summary
- Replace outdated RazerMS, Razer Merchant Services, and MOLPay references with Fiuu branding
- Update old razer.com emails to fiuu.com
- Fix links pointing to old RazerMS GitHub repositories

## Related Issue
Fixes documentation issues reported in GitLab issue #16.